### PR TITLE
Fix black screen: guard animation against failed spritesheet load

### DIFF
--- a/src/entities/EnemyWyvern.js
+++ b/src/entities/EnemyWyvern.js
@@ -14,11 +14,16 @@ export class EnemyWyvern {
     this._shootInterval = Phaser.Math.Between(1200, 2400);
 
     this.sprite = scene.physics.add.sprite(x, y, 'enemy_wyvern');
-    this.sprite.setScale(0.12);
+    const hasAnim = scene.anims.exists('wyvern_fly');
+    if (hasAnim) {
+      this.sprite.setScale(0.12);
+    }
     this.sprite.setVelocityY(90 + Phaser.Math.Between(0, 40));
     this.sprite.setDepth(10);
     this.sprite.setFlipY(true);
-    this.sprite.play('wyvern_fly');
+    if (hasAnim) {
+      this.sprite.play('wyvern_fly');
+    }
 
     scene.enemies.add(this.sprite);
     this.sprite.setData('entity', this);

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -8,6 +8,10 @@ export class BootScene extends Phaser.Scene {
   }
 
   preload() {
+    this._wyvernLoaded = false;
+    this.load.once('filecomplete-spritesheet-enemy_wyvern', () => {
+      this._wyvernLoaded = true;
+    });
     this.load.spritesheet('enemy_wyvern', 'assets/IMG_0278.png', {
       frameWidth: 341,
       frameHeight: 512,
@@ -16,17 +20,25 @@ export class BootScene extends Phaser.Scene {
 
   create() {
     this._createDragon();
+    if (!this._wyvernLoaded) {
+      this._createEnemyWyvern();
+    }
     this._createFireball();
     this._createEnemyShot();
     this._createParticle();
     this._createBackground();
 
-    this.anims.create({
-      key: 'wyvern_fly',
-      frames: this.anims.generateFrameNumbers('enemy_wyvern', { start: 0, end: 5 }),
-      frameRate: 6,
-      repeat: -1,
-    });
+    if (this._wyvernLoaded) {
+      const frames = this.anims.generateFrameNumbers('enemy_wyvern', { start: 0, end: 5 });
+      if (frames.length > 0) {
+        this.anims.create({
+          key: 'wyvern_fly',
+          frames,
+          frameRate: 6,
+          repeat: -1,
+        });
+      }
+    }
 
     this.scene.start('Game');
   }
@@ -53,6 +65,22 @@ export class BootScene extends Phaser.Scene {
     g.fillStyle(0x8b6914);
     g.fillRect(19, 10, 10, 14);
     g.generateTexture('dragon', 48, 48);
+    g.destroy();
+  }
+
+  _createEnemyWyvern() {
+    const g = this.make.graphics({ add: false });
+    g.fillStyle(0x1a3a0a);
+    g.fillRect(10, 8, 20, 28);
+    g.fillStyle(0x2d6b1a);
+    g.fillTriangle(10, 12, 0, 36, 10, 36);
+    g.fillTriangle(30, 12, 40, 36, 30, 36);
+    g.fillStyle(0x1a3a0a);
+    g.fillRect(13, 0, 14, 10);
+    g.fillStyle(0xff3300);
+    g.fillRect(15, 2, 4, 4);
+    g.fillRect(21, 2, 4, 4);
+    g.generateTexture('enemy_wyvern', 40, 40);
     g.destroy();
   }
 


### PR DESCRIPTION
Add a filecomplete event flag so create() knows whether IMG_0278.png actually loaded. If it didn't, fall back to the procedural enemy_wyvern placeholder so scene.start('Game') always runs. Also guard the play() call in EnemyWyvern so a missing animation never crashes enemy spawn.

https://claude.ai/code/session_01BuUhSEA4hjA4JZQSw9A3Tf