### PR TITLE
Add GitHub HUD button with hover and press feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Open `http://localhost:8080` in your browser.
 | Arrow keys | Move dragon |
 | Z | Fire |
 | R | Restart (after game over) |
+| ⭐ GitHub button (top-right) | Open project repository |
 
 **Touch (iOS / Android)**
 

--- a/src/scenes/UIScene.js
+++ b/src/scenes/UIScene.js
@@ -22,6 +22,40 @@ export class UIScene extends Phaser.Scene {
       fontStyle: 'bold',
     }).setOrigin(0.5, 0);
 
+    // GitHub button
+    this.githubButton = this.add.text(470, 10, '⭐ GitHub', {
+      fontSize: '13px',
+      color: '#f8db8d',
+      fontStyle: 'bold',
+      backgroundColor: '#2a1a12',
+      padding: { x: 10, y: 6 },
+    })
+      .setOrigin(1, 0)
+      .setDepth(100)
+      .setInteractive({ useHandCursor: true });
+
+    this.githubButton
+      .on('pointerover', () => {
+        this.githubButton.setStyle({
+          color: '#fff5d6',
+          backgroundColor: '#4a2a18',
+        });
+      })
+      .on('pointerout', () => {
+        this.githubButton.setStyle({
+          color: '#f8db8d',
+          backgroundColor: '#2a1a12',
+        });
+        this.githubButton.setScale(1);
+      })
+      .on('pointerdown', () => {
+        this.githubButton.setScale(0.97);
+        window.open('https://github.com/malcolm-davidson/claude-game-experiment', '_blank', 'noopener,noreferrer');
+      })
+      .on('pointerup', () => {
+        this.githubButton.setScale(1);
+      });
+
     // HP bar
     this.add.text(10, 620, 'HP', { fontSize: '12px', color: '#cc3333' });
     this.hpBarBg = this.add.rectangle(35, 624, 120, 10, 0x330000).setOrigin(0, 0.5);


### PR DESCRIPTION
### Motivation
- Make the project repository easy to access from the running game by adding a visible, tappable GitHub button in the HUD overlay.
- Provide basic hover and press feedback so the button is discoverable and feels responsive on desktop and touch devices.

### Description
- Added a new `⭐ GitHub` Phaser text button in `UIScene.create()` at `x: 470`, `y: 10` with `.setOrigin(1, 0)` and elevated `setDepth(100)` so it stays above gameplay visuals (`src/scenes/UIScene.js`).
- Made the text interactive with `setInteractive({ useHandCursor: true })` and wired the click to `window.open('https://github.com/malcolm-davidson/claude-game-experiment', '_blank', 'noopener,noreferrer')`.
- Implemented `pointerover`, `pointerout`, `pointerdown`, and `pointerup` handlers to swap styles and apply a small press-scale effect, and added `padding` for improved tap hit area.
- Updated the README Controls table to mention the top-right GitHub button (`README.md`).

### Testing
- Ran `npm run build` successfully to ensure the production bundle compiles without errors.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 8080` and verified the button appears in the top-right of the HUD.
- Captured a verification screenshot of the running app to confirm visual placement and interactivity (artifact produced during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a94f25298832bba42c1b20d088c73)